### PR TITLE
Change app-port to 5001 to match README

### DIFF
--- a/bindings/javascript/sdk/README.md
+++ b/bindings/javascript/sdk/README.md
@@ -60,7 +60,7 @@ timeout_seconds: 30
 -->
     
 ```bash
-dapr run --app-id javascript-quickstart-binding-sdk --app-port 5001 --dapr-http-port 3500 --components-path ../../../components -- node index.js
+dapr run --app-id javascript-quickstart-binding-sdk --app-port 5002 --dapr-http-port 3500 --components-path ../../../components -- node index.js
 ```
 
 <!-- END_STEP -->

--- a/bindings/javascript/sdk/batch/index.js
+++ b/bindings/javascript/sdk/batch/index.js
@@ -24,7 +24,7 @@ const postgresBindingName = "sqldb";
 const daprHost = process.env.DAPR_HOST || 'http://localhost';
 const daprPort = process.env.DAPR_HTTP_PORT || '3500';
 const serverHost = "127.0.0.1";
-const serverPort = process.env.SERVER_PORT || '5002';
+const serverPort = process.env.SERVER_PORT || '5001';
 
 const client = new DaprClient(daprHost, daprPort);
 

--- a/bindings/javascript/sdk/batch/index.js
+++ b/bindings/javascript/sdk/batch/index.js
@@ -24,7 +24,7 @@ const postgresBindingName = "sqldb";
 const daprHost = process.env.DAPR_HOST || 'http://localhost';
 const daprPort = process.env.DAPR_HTTP_PORT || '3500';
 const serverHost = "127.0.0.1";
-const serverPort = process.env.SERVER_PORT || '5001';
+const serverPort = process.env.SERVER_PORT || '5002';
 
 const client = new DaprClient(daprHost, daprPort);
 


### PR DESCRIPTION
Change the SDK example to run the app on 5001 to match the dapr run command in the README